### PR TITLE
Remove arunika-ui from projects.yaml

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -49,7 +49,6 @@ projects:
       - ShivankG0EL
       - thecoderwithHat
       - DoctorDictator
-      - arunika-ui
       - Jaysharmamuj
 
   NPTEL:


### PR DESCRIPTION
This pull request makes a small update to the `projects.yaml` file by removing the `arunika-ui` project from the list.